### PR TITLE
Add logger to handler creation in main, update api.yaml, fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a id="markdown-Nexpose Vulnerability Hydrator" name="Nexpose Vulnerability Hydrator"></a>
+<a id="markdown-Nexpose-Vulnerability-Hydrator" name="Nexpose Vulnerability Hydrator"></a>
 # Nexpose Vulnerability Hydrator
 
 <https://github.com/asecurityteam/nexpose-vuln-hydrator>
@@ -52,7 +52,6 @@ configuration.
 
 The app should now be running on port 8080.
 
-`curl -vX POST "http://localhost:8080" -H "Content-Type:application/json" -d @pkg/handlers/v1/testdata/config.valid.json`
 
 <a id="markdown-configuration" name="configuration"></a>
 ## Configuration

--- a/api.yaml
+++ b/api.yaml
@@ -58,7 +58,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Asset'
+              anyOf:
+                # an asset needs either a hostname OR an IP (or both)
+                - $ref: '#/components/schemas/AssetWithIP'
+                - $ref: '#/components/schemas/AssetWithHostname'
       responses:
         "200":
           description: "Success"
@@ -82,7 +85,31 @@ paths:
           error: '{"status": 500, "bodyPassthrough": true}'
 components:
   schemas:
-    Asset:
+    AssetWithHostname:
+      type: object
+      required:
+        - id
+        - hostname
+        - lastScanned
+      properties:
+        hostname:
+          type: string
+          example: corporate-workstation-1102DC.acme.com
+          description: The primary host name (local or FQDN) of the asset.
+        id:
+          type: integer
+          format: int64
+          example: 282
+          description: The identifier of the asset.
+        ip:
+          type: string
+          example: 182.34.74.202
+          description: The primary IPv4 or IPv6 address of the asset.
+        lastScanned:
+          type: string
+          format: date-time
+          description: The last time the asset was scanned.
+    AssetWithIP:
       type: object
       required:
         - id

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	producer "github.com/asecurityteam/component-producer"
 	v1 "github.com/asecurityteam/nexpose-vuln-hydrator/pkg/handlers/v1"
 	"github.com/asecurityteam/nexpose-vuln-hydrator/pkg/hydrator"
+	"github.com/asecurityteam/runhttp"
 	"github.com/asecurityteam/serverfull"
 	"github.com/asecurityteam/settings"
 )
@@ -70,6 +71,7 @@ func (c *component) New(ctx context.Context, conf *config) (func(context.Context
 	hydrationHandler := &v1.HydrationHandler{
 		Hydrator: assetHydrator,
 		Producer: p,
+		LogFn:    runhttp.LoggerFromContext,
 	}
 	handlers := map[string]serverfull.Function{
 		"hydrate": serverfull.NewFunction(hydrationHandler.Handle),


### PR DESCRIPTION
There was a panic in the logs due to the handler not having a logger configured. Adding the logger from context should fix it.

Also make small fix-ups to README and updated api.yml to match schema here: https://bitbucket.org/asecurityteam/nexpose-vuln-hydrator/src/f1bf593d652b631f057e98fb8d4ad1fa301e7a11/gateway-incoming-private.yaml