### PR TITLE
Psd 65/filter invulnerability status

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -184,6 +184,10 @@ components:
             independent results.
           items:
             $ref: '#/components/schemas/AssessmentResult'
+        status:
+          type: string
+          example: vulnerable
+          description: status of a vulnerability, can be used to filter on
         cvssV2Score:
           type: number
           format: double

--- a/pkg/domain/hydrator.go
+++ b/pkg/domain/hydrator.go
@@ -18,6 +18,7 @@ type AssessmentResult struct {
 type VulnerabilityDetails struct {
 	ID             string
 	Results        []AssessmentResult
+	Status         string
 	CvssV2Score    float64
 	CvssV2Severity string
 	Description    string

--- a/pkg/hydrator/batch.go
+++ b/pkg/hydrator/batch.go
@@ -104,6 +104,7 @@ func (a *assetVulnerabilityHydrator) HydrateAssetVulnerability(ctx context.Conte
 			vulnerabilityDetails.CvssV2Severity = nexposeVulnDetails.CvssV2Severity
 			vulnerabilityDetails.Description = nexposeVulnDetails.Description
 			vulnerabilityDetails.Title = nexposeVulnDetails.Title
+			vulnerabilityDetails.Status = nexposeVulnDetails.Status
 		case err := <-errorChan:
 			cancel()
 			return domain.VulnerabilityDetails{}, err

--- a/pkg/hydrator/nexpose.go
+++ b/pkg/hydrator/nexpose.go
@@ -28,6 +28,7 @@ type NexposeVulnerability struct {
 	CvssV2Score    float64
 	CvssV2Severity string
 	Description    string
+	Status         string
 	Title          string
 }
 
@@ -120,6 +121,7 @@ type vulnerabilityDetails struct {
 	RiskScore       float32           `json:"riskScore"`
 	Severity        string            `json:"severity"`
 	Title           string            `json:"title"`
+	Status          string            `json:"status"`
 }
 
 type cvss struct {
@@ -209,6 +211,7 @@ func (n *NexposeClient) FetchVulnerabilityDetails(ctx context.Context, vulnID st
 	}
 	return NexposeVulnerability{
 		Title:          vulnDetails.Title,
+		Status:         vulnDetails.Status,
 		Description:    vulnDetails.Description.Text,
 		CvssV2Score:    vulnDetails.CVSS.V2.Score,
 		CvssV2Severity: cvssV2Severity(vulnDetails.CVSS.V2.Score),


### PR DESCRIPTION
Added a status field that gets captured from Nexpose response. This status field is added to the payload, where it ultimately gets consumed by vuln-filter