### PR TITLE
PSD-65 Add Asset Vulnerability status to output

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -184,6 +184,10 @@ components:
             independent results.
           items:
             $ref: '#/components/schemas/AssessmentResult'
+        status:
+          type: string
+          example: vulnerable
+          description: status of a vulnerability, can be used to filter on
         cvssV2Score:
           type: number
           format: double

--- a/pkg/domain/hydrator.go
+++ b/pkg/domain/hydrator.go
@@ -18,6 +18,7 @@ type AssessmentResult struct {
 type VulnerabilityDetails struct {
 	ID             string
 	Results        []AssessmentResult
+	Status         string
 	CvssV2Score    float64
 	CvssV2Severity string
 	Description    string

--- a/pkg/handlers/v1/hydrator.go
+++ b/pkg/handlers/v1/hydrator.go
@@ -39,6 +39,7 @@ type AssetVulnerabilityDetails struct {
 	Description    string             `json:"description"`
 	Title          string             `json:"title"`
 	Solutions      []string           `json:"solutions"`
+	Status         string             `json:"status"`
 }
 
 // AssessmentResult contains information about the port/protocol the vulnerability was discovered on
@@ -76,6 +77,7 @@ func domainAssetVulnerabilityDetailsToEvent(a domain.AssetVulnerabilityDetails) 
 			Description:    vuln.Description,
 			Title:          vuln.Title,
 			Solutions:      vuln.Solutions,
+			Status:         vuln.Status,
 		}
 	}
 	return AssetVulnerabilitiesEvent{

--- a/pkg/hydrator/batch.go
+++ b/pkg/hydrator/batch.go
@@ -93,6 +93,7 @@ func (a *assetVulnerabilityHydrator) HydrateAssetVulnerability(ctx context.Conte
 	vulnerabilityDetails := domain.VulnerabilityDetails{
 		ID:      assetVulnerability.ID,
 		Results: assetVulnerability.Results,
+		Status:  assetVulnerability.Status,
 	}
 
 	for i := 0; i < 2; i = i + 1 {
@@ -104,7 +105,6 @@ func (a *assetVulnerabilityHydrator) HydrateAssetVulnerability(ctx context.Conte
 			vulnerabilityDetails.CvssV2Severity = nexposeVulnDetails.CvssV2Severity
 			vulnerabilityDetails.Description = nexposeVulnDetails.Description
 			vulnerabilityDetails.Title = nexposeVulnDetails.Title
-			vulnerabilityDetails.Status = nexposeVulnDetails.Status
 		case err := <-errorChan:
 			cancel()
 			return domain.VulnerabilityDetails{}, err

--- a/pkg/hydrator/batch.go
+++ b/pkg/hydrator/batch.go
@@ -104,6 +104,7 @@ func (a *assetVulnerabilityHydrator) HydrateAssetVulnerability(ctx context.Conte
 			vulnerabilityDetails.CvssV2Severity = nexposeVulnDetails.CvssV2Severity
 			vulnerabilityDetails.Description = nexposeVulnDetails.Description
 			vulnerabilityDetails.Title = nexposeVulnDetails.Title
+			vulnerabilityDetails.Status = nexposeVulnDetails.Status
 		case err := <-errorChan:
 			cancel()
 			return domain.VulnerabilityDetails{}, err

--- a/pkg/hydrator/batch_test.go
+++ b/pkg/hydrator/batch_test.go
@@ -65,7 +65,9 @@ func TestHydrateAssetVulnerabilityDetailsFetchError(t *testing.T) {
 		context.Background(),
 		NexposeAssetVulnerability{
 			ID:      "vulnID",
-			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}}},
+			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}},
+			Status:  "vulnerable",
+		},
 	)
 	assert.NotNil(t, err)
 }
@@ -91,7 +93,9 @@ func TestHydrateAssetVulnerabilityVulnSolutionsFetchError(t *testing.T) {
 		context.Background(),
 		NexposeAssetVulnerability{
 			ID:      "vulnID",
-			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}}},
+			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}},
+			Status:  "vulnerable",
+		},
 	)
 	assert.NotNil(t, err)
 }
@@ -118,7 +122,9 @@ func TestHydrateAssetVulnerabilityBatchSolutionsFetchError(t *testing.T) {
 		context.Background(),
 		NexposeAssetVulnerability{
 			ID:      "vulnID",
-			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}}},
+			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}},
+			Status:  "vulnerable",
+		},
 	)
 	assert.NotNil(t, err)
 }
@@ -143,6 +149,7 @@ func TestHydrateAssetVulnerability(t *testing.T) {
 				CvssV2Severity: "Medium",
 				Description:    "medium severity vuln",
 				Title:          "Vulnerability",
+				Status:         "invulnerable",
 			},
 			nil,
 			[]string{"solution1", "solution2"},
@@ -159,6 +166,7 @@ func TestHydrateAssetVulnerability(t *testing.T) {
 				Description:    "medium severity vuln",
 				Title:          "Vulnerability",
 				Solutions:      []string{"solution1-steps", "solution2-steps"},
+				Status:         "invulnerable",
 			},
 			false,
 		},
@@ -240,7 +248,9 @@ func TestHydrateAssetVulnerability(t *testing.T) {
 				context.Background(),
 				NexposeAssetVulnerability{
 					ID:      vulnID,
-					Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}}},
+					Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}},
+					Status:  "invulnerable",
+				},
 			)
 			if test.expectedErr {
 				assert.NotNil(tt, err)

--- a/pkg/hydrator/hydrator_test.go
+++ b/pkg/hydrator/hydrator_test.go
@@ -23,15 +23,15 @@ func TestHydrator(t *testing.T) {
 	}{
 		{
 			"success",
-			[]NexposeAssetVulnerability{NexposeAssetVulnerability{ID: "vuln1"}},
+			[]NexposeAssetVulnerability{NexposeAssetVulnerability{ID: "vuln1", Status: "vulnerable"}},
 			nil,
-			[]domain.VulnerabilityDetails{domain.VulnerabilityDetails{ID: "vuln1"}},
+			[]domain.VulnerabilityDetails{domain.VulnerabilityDetails{ID: "vuln1", Status: "vulnerable"}},
 			nil,
 			domain.AssetVulnerabilityDetails{
 				Asset: domain.Asset{
 					ID: assetID,
 				},
-				Vulnerabilities: []domain.VulnerabilityDetails{domain.VulnerabilityDetails{ID: "vuln1"}},
+				Vulnerabilities: []domain.VulnerabilityDetails{domain.VulnerabilityDetails{ID: "vuln1", Status: "vulnerable"}},
 			},
 			false,
 		},

--- a/pkg/hydrator/nexpose.go
+++ b/pkg/hydrator/nexpose.go
@@ -28,6 +28,7 @@ type NexposeVulnerability struct {
 	CvssV2Score    float64
 	CvssV2Severity string
 	Description    string
+	Status         string
 	Title          string
 }
 
@@ -120,6 +121,7 @@ type vulnerabilityDetails struct {
 	RiskScore       float32           `json:"riskScore"`
 	Severity        string            `json:"severity"`
 	Title           string            `json:"title"`
+	Status          string            `json:"status"`
 }
 
 type cvss struct {
@@ -209,6 +211,7 @@ func (n *NexposeClient) FetchVulnerabilityDetails(ctx context.Context, vulnID st
 	}
 	return NexposeVulnerability{
 		Title:          vulnDetails.Title,
+		Status:         vulnDetails.Status,
 		Description:    vulnDetails.Description.Text,
 		CvssV2Score:    vulnDetails.CVSS.V2.Score,
 		CvssV2Severity: cvssV2Severity(vulnDetails.CVSS.V2.Score),

--- a/pkg/hydrator/nexpose.go
+++ b/pkg/hydrator/nexpose.go
@@ -21,6 +21,7 @@ const (
 type NexposeAssetVulnerability struct {
 	ID      string
 	Results []domain.AssessmentResult
+	Status  string
 }
 
 // NexposeVulnerability represents the relevant fields from a Nexpose Vulnerability
@@ -121,7 +122,6 @@ type vulnerabilityDetails struct {
 	RiskScore       float32           `json:"riskScore"`
 	Severity        string            `json:"severity"`
 	Title           string            `json:"title"`
-	Status          string            `json:"status"`
 }
 
 type cvss struct {
@@ -211,7 +211,6 @@ func (n *NexposeClient) FetchVulnerabilityDetails(ctx context.Context, vulnID st
 	}
 	return NexposeVulnerability{
 		Title:          vulnDetails.Title,
-		Status:         vulnDetails.Status,
 		Description:    vulnDetails.Description.Text,
 		CvssV2Score:    vulnDetails.CVSS.V2.Score,
 		CvssV2Severity: cvssV2Severity(vulnDetails.CVSS.V2.Score),
@@ -320,6 +319,7 @@ func assetVulnToNexposeAssetVuln(resource resource) NexposeAssetVulnerability {
 	return NexposeAssetVulnerability{
 		ID:      resource.ID,
 		Results: results,
+		Status:  resource.Status,
 	}
 }
 


### PR DESCRIPTION
Added a status field that gets captured from Nexpose response. This status field is added to the payload, where it ultimately gets consumed by vuln-filter