### PR TITLE
PSD-99 Add 'proof' field to vuln info

### DIFF
--- a/gateway-outgoing.yaml
+++ b/gateway-outgoing.yaml
@@ -546,6 +546,9 @@ components:
           type: string
           example: tcp
           description: The protocol of the service the result was discovered on.
+        proof:
+          type: string
+          description: The proof explaining why the result was found vulnerable. The proof may container embedded HTML formatting markup.
     AssetVulnerabilityEventWithHostname:
       type: object
       description: "AssetVulnerabilityEventWithHostname contains the Asset info, and has vulnerability details"

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
 	golang.org/x/sys v0.0.0-20190730183949-1393eb018365 // indirect
+	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610
 	google.golang.org/grpc v1.22.1 // indirect
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
 )

--- a/pkg/domain/hydrator.go
+++ b/pkg/domain/hydrator.go
@@ -1,6 +1,8 @@
 package domain
 
-import "context"
+import (
+	"context"
+)
 
 // AssetVulnerabilityDetails is a struct containing the asset information with vulnerabilities
 type AssetVulnerabilityDetails struct {
@@ -8,10 +10,11 @@ type AssetVulnerabilityDetails struct {
 	Vulnerabilities []VulnerabilityDetails
 }
 
-// AssessmentResult contains port and protcol information from Nexpose scanning
+// AssessmentResult contains port and protocol, and proof information from Nexpose scanning
 type AssessmentResult struct {
 	Port     int32
 	Protocol string
+	Proof    string
 }
 
 // VulnerabilityDetails contains the vulnerability information

--- a/pkg/handlers/v1/hydrator.go
+++ b/pkg/handlers/v1/hydrator.go
@@ -43,10 +43,11 @@ type AssetVulnerabilityDetails struct {
 	Status         string             `json:"status"`
 }
 
-// AssessmentResult contains information about the port/protocol the vulnerability was discovered on
+// AssessmentResult contains information about how the vulnerability was discovered
 type AssessmentResult struct {
 	Port     int32  `json:"port"`
 	Protocol string `json:"protocol"`
+	Proof    string `json:"proof"`
 }
 
 // Handle accepts AssetEvents and returns a hydrated asset containing vulnerability information

--- a/pkg/handlers/v1/hydrator_test.go
+++ b/pkg/handlers/v1/hydrator_test.go
@@ -98,8 +98,8 @@ func TestDomainAssetVulnerabilityDetailsToEvent(t *testing.T) {
 				Title:          "cert expired",
 				Solutions:      []string{"update your cert", "alternate"},
 				Results: []domain.AssessmentResult{
-					domain.AssessmentResult{Port: 443, Protocol: "tcp"},
-					domain.AssessmentResult{Port: 80, Protocol: "tcp"},
+					domain.AssessmentResult{Port: 443, Protocol: "tcp", Proof: "This is what happened"},
+					domain.AssessmentResult{Port: 80, Protocol: "tcp", Proof: "Some proof"},
 				},
 			},
 			domain.VulnerabilityDetails{
@@ -110,7 +110,7 @@ func TestDomainAssetVulnerabilityDetailsToEvent(t *testing.T) {
 				Title:          "vuln",
 				Solutions:      []string{"alternate"},
 				Results: []domain.AssessmentResult{
-					domain.AssessmentResult{Port: 443, Protocol: "tcp"},
+					domain.AssessmentResult{Port: 443, Protocol: "tcp", Proof: "Some proof"},
 				},
 			},
 		},

--- a/pkg/hydrator/batch_test.go
+++ b/pkg/hydrator/batch_test.go
@@ -65,7 +65,7 @@ func TestHydrateAssetVulnerabilityDetailsFetchError(t *testing.T) {
 		context.Background(),
 		NexposeAssetVulnerability{
 			ID:      "vulnID",
-			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}},
+			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp", Proof: "Some proof"}},
 			Status:  "vulnerable",
 		},
 	)
@@ -93,7 +93,7 @@ func TestHydrateAssetVulnerabilityVulnSolutionsFetchError(t *testing.T) {
 		context.Background(),
 		NexposeAssetVulnerability{
 			ID:      "vulnID",
-			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}},
+			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp", Proof: "Some proof"}},
 			Status:  "vulnerable",
 		},
 	)
@@ -122,7 +122,7 @@ func TestHydrateAssetVulnerabilityBatchSolutionsFetchError(t *testing.T) {
 		context.Background(),
 		NexposeAssetVulnerability{
 			ID:      "vulnID",
-			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}},
+			Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp", Proof: "Some proof"}},
 			Status:  "vulnerable",
 		},
 	)
@@ -159,7 +159,7 @@ func TestHydrateAssetVulnerability(t *testing.T) {
 			domain.VulnerabilityDetails{
 				ID: "vulnID",
 				Results: []domain.AssessmentResult{
-					domain.AssessmentResult{Port: 443, Protocol: "tcp"},
+					domain.AssessmentResult{Port: 443, Protocol: "tcp", Proof: "Some proof"},
 				},
 				CvssV2Score:    6.5,
 				CvssV2Severity: "Medium",
@@ -248,7 +248,7 @@ func TestHydrateAssetVulnerability(t *testing.T) {
 				context.Background(),
 				NexposeAssetVulnerability{
 					ID:      vulnID,
-					Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp"}},
+					Results: []domain.AssessmentResult{domain.AssessmentResult{Port: 443, Protocol: "tcp", Proof: "Some proof"}},
 					Status:  "invulnerable",
 				},
 			)

--- a/pkg/hydrator/nexpose.go
+++ b/pkg/hydrator/nexpose.go
@@ -314,6 +314,7 @@ func assetVulnToNexposeAssetVuln(resource resource) NexposeAssetVulnerability {
 		results = append(results, domain.AssessmentResult{
 			Port:     result.Port,
 			Protocol: result.Protocol,
+			Proof:    result.Proof,
 		})
 	}
 	return NexposeAssetVulnerability{

--- a/pkg/hydrator/nexpose_test.go
+++ b/pkg/hydrator/nexpose_test.go
@@ -265,7 +265,7 @@ func TestFetchAssetVulnerabilities(t *testing.T) {
 			[]response{
 				{
 					&http.Response{Body: ioutil.NopCloser(bytes.NewBuffer([]byte(
-						`{"page": {"totalPages": 1, "totalResources": 1}, "resources": [{"id": "vuln1", "results": [{"port": 443, "protocol": "tcp"}], "status": "vulnerable"}]}`,
+						`{"page": {"totalPages": 1, "totalResources": 1}, "resources": [{"id": "vuln1", "results": [{"port": 443, "protocol": "tcp", "proof": "some proof"}], "status": "vulnerable"}]}`,
 					)))},
 					nil,
 				},
@@ -275,7 +275,7 @@ func TestFetchAssetVulnerabilities(t *testing.T) {
 				{
 					ID: "vuln1",
 					Results: []domain.AssessmentResult{
-						{Port: 443, Protocol: "tcp"},
+						{Port: 443, Protocol: "tcp", Proof: "some proof"},
 					},
 					Status: "vulnerable",
 				},
@@ -286,13 +286,13 @@ func TestFetchAssetVulnerabilities(t *testing.T) {
 			[]response{
 				{
 					&http.Response{Body: ioutil.NopCloser(bytes.NewBuffer([]byte(
-						`{"page": {"number": 0, "totalPages": 2, "totalResources": 2}, "resources": [{"id": "vuln1", "results": [{"port": 443, "protocol": "tcp"}], "status": "vulnerable"}]}`,
+						`{"page": {"number": 0, "totalPages": 2, "totalResources": 2}, "resources": [{"id": "vuln1", "results": [{"port": 443, "protocol": "tcp", "proof": "some proof"}], "status": "vulnerable"}]}`,
 					)))},
 					nil,
 				},
 				{
 					&http.Response{Body: ioutil.NopCloser(bytes.NewBuffer([]byte(
-						`{"page": {"number": 1, "totalPages": 2, "totalResources": 2}, "resources": [{"id": "vuln2", "results": [{"port": 80, "protocol": "tcp"}], "status": "invulnerable"}]}`,
+						`{"page": {"number": 1, "totalPages": 2, "totalResources": 2}, "resources": [{"id": "vuln2", "results": [{"port": 80, "protocol": "tcp", "proof": "some proof"}], "status": "invulnerable"}]}`,
 					)))},
 					nil,
 				},
@@ -302,14 +302,14 @@ func TestFetchAssetVulnerabilities(t *testing.T) {
 				{
 					ID: "vuln1",
 					Results: []domain.AssessmentResult{
-						{Port: 443, Protocol: "tcp"},
+						{Port: 443, Protocol: "tcp", Proof: "some proof"},
 					},
 					Status: "vulnerable",
 				},
 				{
 					ID: "vuln2",
 					Results: []domain.AssessmentResult{
-						{Port: 80, Protocol: "tcp"},
+						{Port: 80, Protocol: "tcp", Proof: "some proof"},
 					},
 					Status: "invulnerable",
 				},
@@ -320,7 +320,7 @@ func TestFetchAssetVulnerabilities(t *testing.T) {
 			[]response{
 				{
 					&http.Response{Body: ioutil.NopCloser(bytes.NewBuffer([]byte(
-						`{"page": {"number": 0, "totalPages": 2, "totalResources": 2}, "resources": [{"id": "vuln1", "results": [{"port": 443, "protocol": "tcp"}]}]}`,
+						`{"page": {"number": 0, "totalPages": 2, "totalResources": 2}, "resources": [{"id": "vuln1", "results": [{"port": 443, "protocol": "tcp", "proof": "some proof"}]}]}`,
 					)))},
 					nil,
 				},
@@ -391,7 +391,7 @@ func TestMakePagedAssetVulnerabilitiesRequest(t *testing.T) {
 		{
 			"success",
 			&http.Response{
-				Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`{"resources": [{"id": "vuln1", "results": [{"port": 80, "protocol": "tcp"}], "status": "vulnerable"}]}`))),
+				Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`{"resources": [{"id": "vuln1", "results": [{"port": 80, "protocol": "tcp", "proof": "some proof"}], "status": "vulnerable"}]}`))),
 			},
 			nil,
 			false,
@@ -402,6 +402,7 @@ func TestMakePagedAssetVulnerabilitiesRequest(t *testing.T) {
 						{
 							Port:     80,
 							Protocol: "tcp",
+							Proof:    "some proof",
 						},
 					},
 					Status: "vulnerable",
@@ -443,10 +444,12 @@ func TestAssetVulnToNexposeAssetVuln(t *testing.T) {
 			{
 				Port:     443,
 				Protocol: "tcp",
+				Proof:    "some proof",
 			},
 			{
 				Port:     80,
 				Protocol: "tcp",
+				Proof:    "some proof",
 			},
 		},
 		Status: "vulnerable",
@@ -457,8 +460,8 @@ func TestAssetVulnToNexposeAssetVuln(t *testing.T) {
 		NexposeAssetVulnerability{
 			ID: "vulnID",
 			Results: []domain.AssessmentResult{
-				{Port: 443, Protocol: "tcp"},
-				{Port: 80, Protocol: "tcp"},
+				{Port: 443, Protocol: "tcp", Proof: "some proof"},
+				{Port: 80, Protocol: "tcp", Proof: "some proof"},
 			},
 			Status: "vulnerable",
 		},


### PR DESCRIPTION
This change adds the "proof" field to our Nexpose response so we can capture and expose "proof" information in Nexpose VULN tickets.