### PR TITLE
HOT-91382 Hotfix: Make all requests to Nexpose sequentially

### DIFF
--- a/pkg/hydrator/batch.go
+++ b/pkg/hydrator/batch.go
@@ -16,34 +16,14 @@ type batchSolutionFetcher struct {
 }
 
 func (b *batchSolutionFetcher) BatchFetchSolution(ctx context.Context, solutionIDs []string) ([]string, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	solutionsChan := make(chan string, len(solutionIDs))
-	errorChan := make(chan error, len(solutionIDs))
-
-	for _, solutionID := range solutionIDs {
-		go func(id string) {
-			solution, err := b.SolutionFetcher.FetchSolution(ctx, id)
-			if err != nil {
-				errorChan <- err
-				return
-			}
-			solutionsChan <- solution
-		}(solutionID)
-	}
-
 	solutions := make([]string, 0, len(solutionIDs))
-	for range solutionIDs {
-		select {
-		case solution := <-solutionsChan:
-			solutions = append(solutions, solution)
-		case err := <-errorChan:
-			cancel()
+	for _, solutionID := range solutionIDs {
+		solution, err := b.SolutionFetcher.FetchSolution(ctx, solutionID)
+		if err != nil {
 			return nil, err
 		}
+		solutions = append(solutions, solution)
 	}
-
 	return solutions, nil
 }
 
@@ -60,34 +40,14 @@ type batchCheckFetcher struct {
 // BatchFetchCheck fetches all the checks represented by checkIDs, and returns whether they
 // are local, authenticated checks.
 func (b *batchCheckFetcher) BatchFetchCheck(ctx context.Context, checkIDs []string) ([]bool, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	checksChan := make(chan bool, len(checkIDs))
-	errorChan := make(chan error, len(checkIDs))
-
-	for _, checkID := range checkIDs {
-		go func(id string) {
-			check, err := b.CheckFetcher.FetchCheck(ctx, id)
-			if err != nil {
-				errorChan <- err
-				return
-			}
-			checksChan <- check
-		}(checkID)
-	}
-
 	checks := make([]bool, 0, len(checkIDs))
-	for range checkIDs {
-		select {
-		case check := <-checksChan:
-			checks = append(checks, check)
-		case err := <-errorChan:
-			cancel()
+	for _, checkID := range checkIDs {
+		check, err := b.CheckFetcher.FetchCheck(ctx, checkID)
+		if err != nil {
 			return nil, err
 		}
+		checks = append(checks, check)
 	}
-
 	return checks, nil
 }
 
@@ -106,74 +66,39 @@ type assetVulnerabilityHydrator struct {
 }
 
 func (a *assetVulnerabilityHydrator) HydrateAssetVulnerability(ctx context.Context, assetVulnerability NexposeAssetVulnerability) (domain.VulnerabilityDetails, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	errorChan := make(chan error, 3)
-
-	vulnerabilityDetailsChan := make(chan NexposeVulnerability, 1)
-	go func() {
-		details, err := a.VulnerabilityDetailsFetcher.FetchVulnerabilityDetails(ctx, assetVulnerability.ID)
-		if err != nil {
-			errorChan <- err
-			return
-		}
-		vulnerabilityDetailsChan <- details
-	}()
-
-	solutionsChan := make(chan []string, 1)
-	go func() {
-		solutionIDs, err := a.VulnerabilitySolutionsFetcher.FetchVulnerabilitySolutions(ctx, assetVulnerability.ID)
-		if err != nil {
-			errorChan <- err
-			return
-		}
-		solutions, err := a.BatchSolutionFetcher.BatchFetchSolution(ctx, solutionIDs)
-		if err != nil {
-			errorChan <- err
-			return
-		}
-		solutionsChan <- solutions
-	}()
-
-	checksChan := make(chan []bool, 1)
-	go func() {
-		checkIDs, err := a.VulnerabilityChecksFetcher.FetchVulnerabilityChecks(ctx, assetVulnerability.ID)
-		if err != nil {
-			errorChan <- err
-			return
-		}
-		checks, err := a.BatchCheckFetcher.BatchFetchCheck(ctx, checkIDs)
-		if err != nil {
-			errorChan <- err
-			return
-		}
-		checksChan <- checks
-	}()
-
+	vulnDetails, err := a.VulnerabilityDetailsFetcher.FetchVulnerabilityDetails(ctx, assetVulnerability.ID)
+	if err != nil {
+		return domain.VulnerabilityDetails{}, err
+	}
 	vulnerabilityDetails := domain.VulnerabilityDetails{
-		ID:      assetVulnerability.ID,
-		Results: assetVulnerability.Results,
-		Status:  assetVulnerability.Status,
+		ID:             assetVulnerability.ID,
+		Results:        assetVulnerability.Results,
+		Status:         assetVulnerability.Status,
+		CvssV2Score:    vulnDetails.CvssV2Score,
+		CvssV2Severity: vulnDetails.CvssV2Severity,
+		Description:    vulnDetails.Description,
+		Title:          vulnDetails.Title,
 	}
 
-	for i := 0; i < 3; i = i + 1 {
-		select {
-		case solutions := <-solutionsChan:
-			vulnerabilityDetails.Solutions = solutions
-		case checks := <-checksChan:
-			vulnerabilityDetails.LocalCheck = anyTrue(checks)
-		case nexposeVulnDetails := <-vulnerabilityDetailsChan:
-			vulnerabilityDetails.CvssV2Score = nexposeVulnDetails.CvssV2Score
-			vulnerabilityDetails.CvssV2Severity = nexposeVulnDetails.CvssV2Severity
-			vulnerabilityDetails.Description = nexposeVulnDetails.Description
-			vulnerabilityDetails.Title = nexposeVulnDetails.Title
-		case err := <-errorChan:
-			cancel()
-			return domain.VulnerabilityDetails{}, err
-		}
+	solutionIDs, err := a.VulnerabilitySolutionsFetcher.FetchVulnerabilitySolutions(ctx, assetVulnerability.ID)
+	if err != nil {
+		return domain.VulnerabilityDetails{}, err
 	}
+	solutions, err := a.BatchSolutionFetcher.BatchFetchSolution(ctx, solutionIDs)
+	if err != nil {
+		return domain.VulnerabilityDetails{}, err
+	}
+	vulnerabilityDetails.Solutions = solutions
 
+	checkIDs, err := a.VulnerabilityChecksFetcher.FetchVulnerabilityChecks(ctx, assetVulnerability.ID)
+	if err != nil {
+		return domain.VulnerabilityDetails{}, err
+	}
+	checks, err := a.BatchCheckFetcher.BatchFetchCheck(ctx, checkIDs)
+	if err != nil {
+		return domain.VulnerabilityDetails{}, err
+	}
+	vulnerabilityDetails.LocalCheck = anyTrue(checks)
 	return vulnerabilityDetails, nil
 }
 
@@ -187,34 +112,14 @@ type batchAssetVulnerabilityHydrator struct {
 }
 
 func (b *batchAssetVulnerabilityHydrator) BatchHydrateAssetVulnerabilities(ctx context.Context, assetVulns []NexposeAssetVulnerability) ([]domain.VulnerabilityDetails, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	vulnerabilityDetailsChan := make(chan domain.VulnerabilityDetails, len(assetVulns))
-	errorChan := make(chan error, len(assetVulns))
-
-	for _, assetVuln := range assetVulns {
-		go func(assetVuln NexposeAssetVulnerability) {
-			details, err := b.AssetVulnerabilityHydrator.HydrateAssetVulnerability(ctx, assetVuln)
-			if err != nil {
-				errorChan <- err
-				return
-			}
-			vulnerabilityDetailsChan <- details
-		}(assetVuln)
-	}
-
 	vulnerabilityDetails := make([]domain.VulnerabilityDetails, 0, len(assetVulns))
-	for range assetVulns {
-		select {
-		case details := <-vulnerabilityDetailsChan:
-			vulnerabilityDetails = append(vulnerabilityDetails, details)
-		case err := <-errorChan:
-			cancel()
+	for _, assetVuln := range assetVulns {
+		details, err := b.AssetVulnerabilityHydrator.HydrateAssetVulnerability(ctx, assetVuln)
+		if err != nil {
 			return nil, err
 		}
+		vulnerabilityDetails = append(vulnerabilityDetails, details)
 	}
-
 	return vulnerabilityDetails, nil
 }
 


### PR DESCRIPTION
Temporary hotfix to remove all concurrency in issuing requests to Nexpose in order to prevent it from getting overloaded.