### PR TITLE
undo concurrency removal

### DIFF
--- a/pkg/hydrator/batch.go
+++ b/pkg/hydrator/batch.go
@@ -16,14 +16,34 @@ type batchSolutionFetcher struct {
 }
 
 func (b *batchSolutionFetcher) BatchFetchSolution(ctx context.Context, solutionIDs []string) ([]string, error) {
-	solutions := make([]string, 0, len(solutionIDs))
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	solutionsChan := make(chan string, len(solutionIDs))
+	errorChan := make(chan error, len(solutionIDs))
+
 	for _, solutionID := range solutionIDs {
-		solution, err := b.SolutionFetcher.FetchSolution(ctx, solutionID)
-		if err != nil {
+		go func(id string) {
+			solution, err := b.SolutionFetcher.FetchSolution(ctx, id)
+			if err != nil {
+				errorChan <- err
+				return
+			}
+			solutionsChan <- solution
+		}(solutionID)
+	}
+
+	solutions := make([]string, 0, len(solutionIDs))
+	for range solutionIDs {
+		select {
+		case solution := <-solutionsChan:
+			solutions = append(solutions, solution)
+		case err := <-errorChan:
+			cancel()
 			return nil, err
 		}
-		solutions = append(solutions, solution)
 	}
+
 	return solutions, nil
 }
 
@@ -40,14 +60,34 @@ type batchCheckFetcher struct {
 // BatchFetchCheck fetches all the checks represented by checkIDs, and returns whether they
 // are local, authenticated checks.
 func (b *batchCheckFetcher) BatchFetchCheck(ctx context.Context, checkIDs []string) ([]bool, error) {
-	checks := make([]bool, 0, len(checkIDs))
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	checksChan := make(chan bool, len(checkIDs))
+	errorChan := make(chan error, len(checkIDs))
+
 	for _, checkID := range checkIDs {
-		check, err := b.CheckFetcher.FetchCheck(ctx, checkID)
-		if err != nil {
+		go func(id string) {
+			check, err := b.CheckFetcher.FetchCheck(ctx, id)
+			if err != nil {
+				errorChan <- err
+				return
+			}
+			checksChan <- check
+		}(checkID)
+	}
+
+	checks := make([]bool, 0, len(checkIDs))
+	for range checkIDs {
+		select {
+		case check := <-checksChan:
+			checks = append(checks, check)
+		case err := <-errorChan:
+			cancel()
 			return nil, err
 		}
-		checks = append(checks, check)
 	}
+
 	return checks, nil
 }
 
@@ -66,39 +106,74 @@ type assetVulnerabilityHydrator struct {
 }
 
 func (a *assetVulnerabilityHydrator) HydrateAssetVulnerability(ctx context.Context, assetVulnerability NexposeAssetVulnerability) (domain.VulnerabilityDetails, error) {
-	vulnDetails, err := a.VulnerabilityDetailsFetcher.FetchVulnerabilityDetails(ctx, assetVulnerability.ID)
-	if err != nil {
-		return domain.VulnerabilityDetails{}, err
-	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errorChan := make(chan error, 3)
+
+	vulnerabilityDetailsChan := make(chan NexposeVulnerability, 1)
+	go func() {
+		details, err := a.VulnerabilityDetailsFetcher.FetchVulnerabilityDetails(ctx, assetVulnerability.ID)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		vulnerabilityDetailsChan <- details
+	}()
+
+	solutionsChan := make(chan []string, 1)
+	go func() {
+		solutionIDs, err := a.VulnerabilitySolutionsFetcher.FetchVulnerabilitySolutions(ctx, assetVulnerability.ID)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		solutions, err := a.BatchSolutionFetcher.BatchFetchSolution(ctx, solutionIDs)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		solutionsChan <- solutions
+	}()
+
+	checksChan := make(chan []bool, 1)
+	go func() {
+		checkIDs, err := a.VulnerabilityChecksFetcher.FetchVulnerabilityChecks(ctx, assetVulnerability.ID)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		checks, err := a.BatchCheckFetcher.BatchFetchCheck(ctx, checkIDs)
+		if err != nil {
+			errorChan <- err
+			return
+		}
+		checksChan <- checks
+	}()
+
 	vulnerabilityDetails := domain.VulnerabilityDetails{
-		ID:             assetVulnerability.ID,
-		Results:        assetVulnerability.Results,
-		Status:         assetVulnerability.Status,
-		CvssV2Score:    vulnDetails.CvssV2Score,
-		CvssV2Severity: vulnDetails.CvssV2Severity,
-		Description:    vulnDetails.Description,
-		Title:          vulnDetails.Title,
+		ID:      assetVulnerability.ID,
+		Results: assetVulnerability.Results,
+		Status:  assetVulnerability.Status,
 	}
 
-	solutionIDs, err := a.VulnerabilitySolutionsFetcher.FetchVulnerabilitySolutions(ctx, assetVulnerability.ID)
-	if err != nil {
-		return domain.VulnerabilityDetails{}, err
+	for i := 0; i < 3; i = i + 1 {
+		select {
+		case solutions := <-solutionsChan:
+			vulnerabilityDetails.Solutions = solutions
+		case checks := <-checksChan:
+			vulnerabilityDetails.LocalCheck = anyTrue(checks)
+		case nexposeVulnDetails := <-vulnerabilityDetailsChan:
+			vulnerabilityDetails.CvssV2Score = nexposeVulnDetails.CvssV2Score
+			vulnerabilityDetails.CvssV2Severity = nexposeVulnDetails.CvssV2Severity
+			vulnerabilityDetails.Description = nexposeVulnDetails.Description
+			vulnerabilityDetails.Title = nexposeVulnDetails.Title
+		case err := <-errorChan:
+			cancel()
+			return domain.VulnerabilityDetails{}, err
+		}
 	}
-	solutions, err := a.BatchSolutionFetcher.BatchFetchSolution(ctx, solutionIDs)
-	if err != nil {
-		return domain.VulnerabilityDetails{}, err
-	}
-	vulnerabilityDetails.Solutions = solutions
 
-	checkIDs, err := a.VulnerabilityChecksFetcher.FetchVulnerabilityChecks(ctx, assetVulnerability.ID)
-	if err != nil {
-		return domain.VulnerabilityDetails{}, err
-	}
-	checks, err := a.BatchCheckFetcher.BatchFetchCheck(ctx, checkIDs)
-	if err != nil {
-		return domain.VulnerabilityDetails{}, err
-	}
-	vulnerabilityDetails.LocalCheck = anyTrue(checks)
 	return vulnerabilityDetails, nil
 }
 
@@ -112,14 +187,34 @@ type batchAssetVulnerabilityHydrator struct {
 }
 
 func (b *batchAssetVulnerabilityHydrator) BatchHydrateAssetVulnerabilities(ctx context.Context, assetVulns []NexposeAssetVulnerability) ([]domain.VulnerabilityDetails, error) {
-	vulnerabilityDetails := make([]domain.VulnerabilityDetails, 0, len(assetVulns))
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	vulnerabilityDetailsChan := make(chan domain.VulnerabilityDetails, len(assetVulns))
+	errorChan := make(chan error, len(assetVulns))
+
 	for _, assetVuln := range assetVulns {
-		details, err := b.AssetVulnerabilityHydrator.HydrateAssetVulnerability(ctx, assetVuln)
-		if err != nil {
+		go func(assetVuln NexposeAssetVulnerability) {
+			details, err := b.AssetVulnerabilityHydrator.HydrateAssetVulnerability(ctx, assetVuln)
+			if err != nil {
+				errorChan <- err
+				return
+			}
+			vulnerabilityDetailsChan <- details
+		}(assetVuln)
+	}
+
+	vulnerabilityDetails := make([]domain.VulnerabilityDetails, 0, len(assetVulns))
+	for range assetVulns {
+		select {
+		case details := <-vulnerabilityDetailsChan:
+			vulnerabilityDetails = append(vulnerabilityDetails, details)
+		case err := <-errorChan:
+			cancel()
 			return nil, err
 		}
-		vulnerabilityDetails = append(vulnerabilityDetails, details)
 	}
+
 	return vulnerabilityDetails, nil
 }
 


### PR DESCRIPTION
This PR undoes the hotfix from last week where we removed concurrency in vuln hydrator's requests to nexpose. This is an attempt to resolve the queue backup currently happening behind vuln hydrator.